### PR TITLE
wrong jansson location in build profiles

### DIFF
--- a/resources/profiles/jdk8_msi.gitmodules.txt
+++ b/resources/profiles/jdk8_msi.gitmodules.txt
@@ -4,7 +4,7 @@ deps/curl
 deps/freetype
 deps/giflib
 deps/icedtea-web
-deps/jansson
+external/jansson
 deps/libjpeg-turbo
 deps/libpng
 deps/nss

--- a/resources/profiles/jdk8_zip.gitmodules.txt
+++ b/resources/profiles/jdk8_zip.gitmodules.txt
@@ -4,7 +4,7 @@ deps/curl
 deps/freetype
 deps/giflib
 deps/icedtea-web
-deps/jansson
+external/jansson
 deps/libjpeg-turbo
 deps/libpng
 deps/nss

--- a/resources/profiles/update_notifier.gitmodules.txt
+++ b/resources/profiles/update_notifier.gitmodules.txt
@@ -4,7 +4,7 @@ deps/curl
 deps/freetype
 deps/giflib
 deps/icedtea-web
-deps/jansson
+external/jansson
 deps/libjpeg-turbo
 deps/libpng
 deps/nss


### PR DESCRIPTION
after a recent project update, for jdk8 builds the jansson dependencies were moved from deps/jansson to external/jansson, but that wasn't updated in various profile files

