### PR TITLE
wrong popt dependency in update notifier

### DIFF
--- a/resources/profiles/update_notifier.gitmodules.txt
+++ b/resources/profiles/update_notifier.gitmodules.txt
@@ -9,7 +9,7 @@ deps/libjpeg-turbo
 deps/libpng
 deps/nss
 deps/openssl
-deps/popt
+external/popt
 deps/rhino
 deps/tagsoup
 deps/zlib


### PR DESCRIPTION
still points to deps/popt instead of external/popt