### PR TITLE
Include registry key for JRE using major version

### DIFF
--- a/src/java-1.8.0-openjdk/resources/jdk_registry_env.xsl
+++ b/src/java-1.8.0-openjdk/resources/jdk_registry_env.xsl
@@ -40,6 +40,13 @@
                 <RegistryValue Name="RuntimeLib" Value="[INSTALLDIR]jre\bin\server\jvm.dll" Type="string"/>
             </RegistryKey>
         </Component>
+        <Component Id="jdk_registry_standard_jre_major" Guid="60efd96e-4f21-4ba4-af37-8606ba163a52" Win64="${${PROJECT_NAME}_INSTALLER_WIN64_WIX}" xmlns="http://schemas.microsoft.com/wix/2006/wi">
+            <RegistryKey Id="jdk_registry_standard_jre_key" ForceCreateOnInstall="yes" Root="HKLM"
+                         Key="Software\JavaSoft\Java Runtime Environment\1.${${PROJECT_NAME}_INSTALLER_JDK_RELEASE}">
+                <RegistryValue Name="JavaHome" Value="[INSTALLDIR]jre\" Type="string"/>
+                <RegistryValue Name="RuntimeLib" Value="[INSTALLDIR]jre\bin\server\jvm.dll" Type="string"/>
+            </RegistryKey>
+        </Component>
 
         <!-- jdk_env_path -->
         <Component Id="jdk_env_path_comp" Guid="d84cb2f5-b3a1-478b-a104-b1defb1b4e32" KeyPath="yes" Win64="${${PROJECT_NAME}_INSTALLER_WIN64_WIX}" xmlns="http://schemas.microsoft.com/wix/2006/wi">


### PR DESCRIPTION
The Oracle JRE installer add registry keys for both the specific build of the JRE/JDK as well as a pointer for the major version.
Example:
`Computer\HKEY_LOCAL_MACHINE\SOFTWARE\JavaSoft\Java Runtime Environment\1.8.0_191_1`
`Computer\HKEY_LOCAL_MACHINE\SOFTWARE\JavaSoft\Java Runtime Environment\1.8`
Both keys will have the same values.

This is useful for software that is just looking for a major version of Java to be installed, and know where it is.
I maintain an installer that looks for JavaHome at `HKLM\SOFTWARE\JavaSoft\Java Runtime Environment\1.8` and this works fine for the Oracle JRE, but the OpenJDK build doesn't include this key.

Patch adds this key with the same data that is in the build specific key.